### PR TITLE
Use FileProvider and content URIs for attachments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,13 +21,20 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
+        exclude 'META-INF/proguard/androidx-annotations.pro'
     }
+
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
 }
 
 dependencies {
     implementation 'com.android.support:support-compat:28.0.0'
     implementation 'org.slf4j:slf4j-api:1.7.7'
     implementation 'com.squareup:seismic:1.0.2'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0') {
+        exclude group: 'org.hamcrest'
+    }
     androidTestImplementation 'org.hamcrest:hamcrest-all:1.3'
     androidTestImplementation('junit:junit:4.11') {
         exclude module: 'hamcrest-core'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ android {
 }
 
 dependencies {
+    implementation 'com.android.support:support-compat:28.0.0'
     implementation 'org.slf4j:slf4j-api:1.7.7'
     implementation 'com.squareup:seismic:1.0.2'
     androidTestImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,17 @@
-apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven' 
+plugins {
+    id 'com.android.library'
+    id 'com.github.dcendents.android-maven'
+}
 
 group='com.github.bright'
 
-
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 28
         versionCode 14
         versionName "1.0"
     }
@@ -24,20 +25,20 @@ android {
 }
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.squareup:seismic:1.0.2'
-    androidTestCompile 'org.hamcrest:hamcrest-all:1.3'
-    androidTestCompile('junit:junit:4.11') {
+    implementation 'org.slf4j:slf4j-api:1.7.7'
+    implementation 'com.squareup:seismic:1.0.2'
+    androidTestImplementation 'org.hamcrest:hamcrest-all:1.3'
+    androidTestImplementation('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }
-    androidTestCompile 'org.easytesting:fest-util:1.2.5'
+    androidTestImplementation 'org.easytesting:fest-util:1.2.5'
 
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile('junit:junit:4.11') {
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }
-    testCompile 'org.easytesting:fest-util:1.2.5'
-    testCompile('org.robolectric:robolectric:3.0') {
+    testImplementation 'org.easytesting:fest-util:1.2.5'
+    testImplementation('org.robolectric:robolectric:3.0') {
         exclude module: 'classworlds'
         exclude module: 'commons-logging'
         exclude module: 'httpclient'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,6 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
-        exclude 'META-INF/proguard/androidx-annotations.pro'
     }
 
     useLibrary 'android.test.runner'
@@ -32,9 +31,6 @@ dependencies {
     implementation 'com.android.support:support-compat:28.0.0'
     implementation 'org.slf4j:slf4j-api:1.7.7'
     implementation 'com.squareup:seismic:1.0.2'
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0') {
-        exclude group: 'org.hamcrest'
-    }
     androidTestImplementation 'org.hamcrest:hamcrest-all:1.3'
     androidTestImplementation('junit:junit:4.11') {
         exclude module: 'hamcrest-core'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,5 +9,14 @@
         <activity
             android:name=".NotifyDeveloperDialogDisplayActivity"
             android:theme="@android:style/Theme.NoDisplay"/>
+        <provider
+            android:name=".Slf4AndroidLogFileProvider"
+            android:authorities="${applicationId}.slf4android.logs.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperDialogDisplayActivity.java
+++ b/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperDialogDisplayActivity.java
@@ -106,11 +106,7 @@ public class NotifyDeveloperDialogDisplayActivity extends Activity {
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     private static void startTaskExecution(Context activityContext, AsyncTask<Context, Void, File> attachment) {
-        if (Build.VERSION.SDK_INT < 11) {
-            attachment.execute(activityContext);
-        } else {
-            attachment.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, activityContext);
-        }
+        attachment.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, activityContext);
     }
 
     private static void sendEmailWithError(Context activityContext, EmailErrorReport emailErrorReport) {

--- a/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperDialogDisplayActivity.java
+++ b/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperDialogDisplayActivity.java
@@ -116,7 +116,7 @@ public class NotifyDeveloperDialogDisplayActivity extends Activity {
         emailErrorReport.configureRecipients(sendEmail);
         emailErrorReport.configureSubject(sendEmail);
         emailErrorReport.configureMessage(sendEmail);
-        emailErrorReport.configureAttachments(sendEmail);
+        emailErrorReport.configureAttachments(sendEmail, activityContext);
 
         try {
             activityContext.startActivity(Intent.createChooser(sendEmail, "Send mail..."));

--- a/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperHandler.java
+++ b/app/src/main/java/pl/brightinventions/slf4android/NotifyDeveloperHandler.java
@@ -115,7 +115,7 @@ public class NotifyDeveloperHandler extends Handler {
         }
         try {
             attachmentClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (Exception e) {
             throw new IllegalArgumentException("Can't create attachment factory from class " + attachmentClass, e);
         }
         attachmentClassList.add(attachmentClass.getName());

--- a/app/src/main/java/pl/brightinventions/slf4android/Slf4AndroidLogFileProvider.java
+++ b/app/src/main/java/pl/brightinventions/slf4android/Slf4AndroidLogFileProvider.java
@@ -1,0 +1,12 @@
+package pl.brightinventions.slf4android;
+
+import android.content.Context;
+import android.support.v4.content.FileProvider;
+
+public class Slf4AndroidLogFileProvider extends FileProvider {
+
+    public static String getAuthority(Context context) {
+        // The suffix must be exactly the same as the one provided in the AndroidManifest.xml
+        return context.getPackageName() + ".slf4android.logs.provider";
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-cache-path name="logs" path="." />
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Android N and newer doesn't allow sharing files between apps using URIs created with `Uri.fromFile()`. Instead, a `FileProvider` should be used. It allows the receiving application to access the files.

It fixes #16